### PR TITLE
chore: when merging always use the pull request title as commitHeadline

### DIFF
--- a/pkg/merge-with-label/github/github.go
+++ b/pkg/merge-with-label/github/github.go
@@ -296,7 +296,12 @@ func MergePullRequest(
 	commitHeadline string,
 ) error {
 	_, err := doGraphQLRequest(ctx, client, token, `
-mutation MergePulLRequest($pullRequestId: ID!, $expectedHeadOid: GitObjectID!, $mergeMethod: PullRequestMergeMethod!, $commitHeadline: String!){ 
+mutation MergePulLRequest(
+  $pullRequestId: ID!,
+  $expectedHeadOid: GitObjectID!,
+  $mergeMethod: PullRequestMergeMethod!,
+  $commitHeadline: String!
+){ 
   mergePullRequest(input: {
     pullRequestId: $pullRequestId,
     expectedHeadOid: $expectedHeadOid,

--- a/pkg/merge-with-label/github/github.go
+++ b/pkg/merge-with-label/github/github.go
@@ -292,14 +292,16 @@ func MergePullRequest(
 	token,
 	pullRequestID,
 	expectedHeadOid,
-	mergeStrategy string,
+	mergeStrategy,
+	commitHeadline string,
 ) error {
 	_, err := doGraphQLRequest(ctx, client, token, `
-mutation MergePulLRequest($pullRequestId: ID!, $expectedHeadOid: GitObjectID!, $mergeMethod: PullRequestMergeMethod!){ 
+mutation MergePulLRequest($pullRequestId: ID!, $expectedHeadOid: GitObjectID!, $mergeMethod: PullRequestMergeMethod!, $commitHeadline: String!){ 
   mergePullRequest(input: {
     pullRequestId: $pullRequestId,
     expectedHeadOid: $expectedHeadOid,
     mergeMethod: $mergeMethod,
+    commitHeadline: $commitHeadline,
   }) {
     clientMutationId
   }
@@ -308,6 +310,7 @@ mutation MergePulLRequest($pullRequestId: ID!, $expectedHeadOid: GitObjectID!, $
 		"pullRequestId":   pullRequestID,
 		"expectedHeadOid": expectedHeadOid,
 		"mergeMethod":     mergeStrategy,
+		"commitHeadline":  commitHeadline,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to merge pull request")

--- a/pkg/merge-with-label/worker/pull_request_worker.go
+++ b/pkg/merge-with-label/worker/pull_request_worker.go
@@ -312,6 +312,7 @@ func (worker *pullRequestWorker) mergePullRequest(
 		details.ID,
 		details.LastCommitSha,
 		cfg.Merge.Strategy.GithubString(),
+		details.Title,
 	); err != nil {
 		var graphQLErrors github.GraphQLErrors
 		if errors.As(err, &graphQLErrors) {


### PR DESCRIPTION
## Description

## Problem
By default, GitHub uses the text from the first commit, which can cause issues as it may not always accurately represent the purpose of the pull request.

## Solution
Modify the bot to consistently utilize the pull request title as the commit message.

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

