### PR TITLE
fix: logging level should be InfoLevel by default

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,10 +24,14 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	logger := zerolog.New(os.Stderr).Level(zerolog.InfoLevel).With().Timestamp().Logger()
 	if os.Getenv("DEBUG") != "" {
 		logger = logger.Level(zerolog.DebugLevel)
 		logger.Debug().Msg("debug logging enabled")
+	}
+	if os.Getenv("TRACE") != "" {
+		logger = logger.Level(zerolog.TraceLevel)
+		logger.Debug().Msg("trace logging enabled")
 	}
 
 	address := os.Getenv("ADDRESS")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -22,10 +22,14 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	logger := zerolog.New(os.Stderr).Level(zerolog.InfoLevel).With().Timestamp().Logger()
 	if os.Getenv("DEBUG") != "" {
 		logger = logger.Level(zerolog.DebugLevel)
 		logger.Debug().Msg("debug logging enabled")
+	}
+	if os.Getenv("TRACE") != "" {
+		logger = logger.Level(zerolog.TraceLevel)
+		logger.Debug().Msg("trace logging enabled")
 	}
 
 	if os.Getenv("APP_ID") == "" {


### PR DESCRIPTION
## Description

## Problem
Debug messages were always printed.

## Solution
Set the default level to info.

## Notes
Also added Trace Level (not needed at the moment)

