### PR TITLE
chore: add merge state status for better visibility why a pull request was not merged

### DIFF
--- a/pkg/merge-with-label/github/github.go
+++ b/pkg/merge-with-label/github/github.go
@@ -424,21 +424,22 @@ query GetPullRequests($query: String!, $after: String){
 }
 
 type PullRequestDetails struct {
-	AheadBy        int
-	ApprovedBy     []string
-	Author         string
-	BaseRefName    string
-	CheckStates    map[string]string
-	HasConflicts   bool
-	HeadRefID      string
-	HeadRefName    string
-	ID             string
-	IsMergeable    bool
-	Labels         []string
-	LastCommitSha  string
-	LastCommitTime time.Time
-	State          string
-	Title          string
+	AheadBy          int
+	ApprovedBy       []string
+	Author           string
+	BaseRefName      string
+	CheckStates      map[string]string
+	HasConflicts     bool
+	HeadRefID        string
+	HeadRefName      string
+	ID               string
+	IsMergeable      bool
+	MergeStateStatus string
+	Labels           []string
+	LastCommitSha    string
+	LastCommitTime   time.Time
+	State            string
+	Title            string
 }
 
 func getPullRequestBaseName(ctx context.Context, client *http.Client, token string, repo *common.Repository, number int64) (string, error) {
@@ -540,10 +541,11 @@ func GetPullRequestDetails(
 							Name string `json:"name"`
 						} `json:"nodes"`
 					} `json:"labels" graphql:"labels(last: 100)"`
-					Mergeable string `json:"mergeable"`
-					State     string `json:"state"`
-					Title     string `json:"title"`
-					Reviews   struct {
+					MergeStateStatus string `json:"mergeStateStatus"`
+					Mergeable        string `json:"mergeable"`
+					State            string `json:"state"`
+					Title            string `json:"title"`
+					Reviews          struct {
 						Nodes []struct {
 							Author struct {
 								Login string `json:"login"`
@@ -592,18 +594,19 @@ func GetPullRequestDetails(
 	}
 
 	details := &PullRequestDetails{
-		AheadBy:      response.Data.Repository.PullRequest.HeadRef.Compare.AheadBy,
-		ApprovedBy:   make([]string, len(response.Data.Repository.PullRequest.Reviews.Nodes)),
-		Author:       response.Data.Repository.PullRequest.Author.Login,
-		BaseRefName:  baseName,
-		HasConflicts: response.Data.Repository.PullRequest.Mergeable == "CONFLICTING",
-		HeadRefID:    response.Data.Repository.PullRequest.HeadRef.ID,
-		HeadRefName:  response.Data.Repository.PullRequest.HeadRef.Name,
-		ID:           response.Data.Repository.PullRequest.ID,
-		IsMergeable:  response.Data.Repository.PullRequest.Mergeable == "MERGEABLE",
-		Labels:       make([]string, len(response.Data.Repository.PullRequest.Labels.Nodes)),
-		State:        response.Data.Repository.PullRequest.State,
-		Title:        response.Data.Repository.PullRequest.Title,
+		AheadBy:          response.Data.Repository.PullRequest.HeadRef.Compare.AheadBy,
+		ApprovedBy:       make([]string, len(response.Data.Repository.PullRequest.Reviews.Nodes)),
+		Author:           response.Data.Repository.PullRequest.Author.Login,
+		BaseRefName:      baseName,
+		HasConflicts:     response.Data.Repository.PullRequest.Mergeable == "CONFLICTING",
+		HeadRefID:        response.Data.Repository.PullRequest.HeadRef.ID,
+		HeadRefName:      response.Data.Repository.PullRequest.HeadRef.Name,
+		ID:               response.Data.Repository.PullRequest.ID,
+		IsMergeable:      response.Data.Repository.PullRequest.Mergeable == "MERGEABLE",
+		MergeStateStatus: response.Data.Repository.PullRequest.MergeStateStatus,
+		Labels:           make([]string, len(response.Data.Repository.PullRequest.Labels.Nodes)),
+		State:            response.Data.Repository.PullRequest.State,
+		Title:            response.Data.Repository.PullRequest.Title,
 	}
 
 	for i := range response.Data.Repository.PullRequest.Reviews.Nodes {

--- a/pkg/merge-with-label/github/github.go
+++ b/pkg/merge-with-label/github/github.go
@@ -117,6 +117,7 @@ func doGraphQLRequest(ctx context.Context, client *http.Client, token, query str
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github.merge-info-preview+json")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/merge-with-label/worker/should_skip.go
+++ b/pkg/merge-with-label/worker/should_skip.go
@@ -334,11 +334,11 @@ func (worker *Worker) shouldSkipBecauseIsNotMergeable(*MergeConfigV1) shouldSkip
 			logger.Debug().Msg("pull request not mergeable, but the the last commit is too recent, retrying")
 			return shouldSkipResult{SkipAction: false}, pushBackError{delay: diff}
 		}
-		logger.Debug().Msg("pull request not mergeable")
+		logger.Debug().Str("merge_state_status", details.MergeStateStatus).Msg("pull request not mergeable")
 		return shouldSkipResult{
 			SkipAction: true,
 			Title:      "not merging",
-			Summary:    "pull request is not mergeable",
+			Summary:    fmt.Sprintf("pull request is not mergeable, state is %s", details.MergeStateStatus),
 		}, nil
 	}
 }

--- a/pkg/merge-with-label/worker/should_skip.go
+++ b/pkg/merge-with-label/worker/should_skip.go
@@ -331,7 +331,8 @@ func (worker *Worker) shouldSkipBecauseIsNotMergeable(*MergeConfigV1) shouldSkip
 
 		if diff := time.Until(details.LastCommitTime.Add(worker.DurationBeforeMergeAfterCheck)); diff > 0 {
 			// it's a bit too early. block merging, push back onto the queue
-			logger.Debug().Msg("pull request not mergeable, but the the last commit is too recent, retrying")
+			logger.Debug().Str("merge_state_status", details.MergeStateStatus).
+				Msg("pull request is not mergeable, but the the last commit is too recent, retrying")
 			return shouldSkipResult{SkipAction: false}, pushBackError{delay: diff}
 		}
 		logger.Debug().Str("merge_state_status", details.MergeStateStatus).Msg("pull request not mergeable")


### PR DESCRIPTION
## Description

## Problem
Its hard to see why a pull request is marked as not mergable. (Could also be the reason for #25)

## Solution
Also fetch MergeStateStatus and add it to the log output and final check message that gets sent to github

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

