### PR TITLE
fix: pass pointer to unmarshal func

### DIFF
--- a/pkg/merge-with-label/worker/worker.go
+++ b/pkg/merge-with-label/worker/worker.go
@@ -150,7 +150,7 @@ func handleMessage[T common.Message](worker *Worker, logger *zerolog.Logger, msg
 	}
 
 	var m T
-	if err := json.Unmarshal(msg.Data, m); err != nil {
+	if err := json.Unmarshal(msg.Data, &m); err != nil {
 		logger.Error().Err(err).Msg("unable to decode queue message")
 		if err := msg.NakWithDelay(worker.RetryWait); err != nil {
 			logger.Error().Err(err).Msg("unable to nak message")


### PR DESCRIPTION
## Description

## Problem
Errors during decoding.
```
{"level":"error","error":"json: Unmarshal(non-pointer common.QueueStatusMessage)","time":"2023-12-22T14:46:49Z","message":"unable to decode queue message"}
```

## Solution
Pass pointer to `json.Unmarshal`

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

