### PR TITLE
chore: avoid work on non master branches

### DIFF
--- a/pkg/merge-with-label/server/base_request.go
+++ b/pkg/merge-with-label/server/base_request.go
@@ -16,7 +16,8 @@ type BaseRequest struct {
 		Owner    struct {
 			Login string `json:"login"`
 		} `json:"owner"`
-		Private bool `json:"private"`
+		Private       bool   `json:"private"`
+		DefaultBranch string `json:"default_branch"`
 	} `json:"repository"`
 }
 


### PR DESCRIPTION
## Description

Push events should only be handled for the main/master/default branch. Checking/updating/merging all pull requests when pushes occur on branches is unnecessary because branch updates will be triggered by the pull_request synchronize event if a pull request exists for that branch.

## Problem
A short description of the problem this PR is addressing.

## Solution
A short description of the chosen method to resolve the problem
with an overview of the logic and implementation details when needed.

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

