### PR TITLE
build: replace two-stage Dockerfile with single-stage runtime image, add goreleaser config

### DIFF
--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -5,47 +5,36 @@ on:
 
 name: "release_published"
 jobs:
-  build:
-    permissions: write-all
+  # Build the binary using GoReleaser
+  build_binary:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       -
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v6.0.3
       -
         name: Install mise
         uses: jdx/mise-action@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Login to Docker Registry
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Check if latest release
-        id: latest
-        run: |
-          LATEST=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
-          echo "IS_LATEST_RELEASE=$([[ "$LATEST" == "${{ github.ref_name }}" ]] && echo true || echo false)" >> "$GITHUB_ENV"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
+        name: GoReleaser
+        run: mise exec -- goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY: ghcr.io
           IMAGE_NAME: eun/merge-with-label
-          IS_LATEST_RELEASE: ${{ env.IS_LATEST_RELEASE }}
+          IS_LATEST_RELEASE: ${{ !github.event.release.prerelease && github.event.release.make_latest != 'false' }}

--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -5,16 +5,23 @@ on:
 
 name: "release_published"
 jobs:
-  # Build the binary using GoReleaser
   build:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
       -
         uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       -
         name: Install mise
         uses: jdx/mise-action@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to Docker Registry
         uses: docker/login-action@v3.7.0
@@ -23,10 +30,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Build and push
-        uses: docker/build-push-action@v6
+        name: Check if latest release
+        id: latest
+        run: |
+          LATEST=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          echo "IS_LATEST_RELEASE=$([[ "$LATEST" == "${{ github.ref_name }}" ]] && echo true || echo false)" >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          push: true
-          tags: |
-            ghcr.io/eun/merge-with-label:latest
-            ghcr.io/eun/merge-with-label:${{ github.ref_name }}
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY: ghcr.io
+          IMAGE_NAME: eun/merge-with-label
+          IS_LATEST_RELEASE: ${{ env.IS_LATEST_RELEASE }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,134 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+project_name: "merge-with-label"
+builds:
+  -
+    id: "server"
+    binary: "server"
+    main: "./cmd/server"
+    env:
+      - "CGO_ENABLED=0"
+    goos:
+      - "linux"
+    goarch:
+      - "arm64"
+      - "amd64"
+    ldflags:
+      - -s
+      - -w
+  -
+    id: "worker"
+    binary: "worker"
+    main: "./cmd/worker"
+    env:
+      - "CGO_ENABLED=0"
+    goos:
+      - "linux"
+    goarch:
+      - "arm64"
+      - "amd64"
+    ldflags:
+      - -s
+      - -w
+archives:
+  - name_template: "merge-with-label_{{.Version}}_{{.Os}}_{{.Arch}}"
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  version_template: "{{.Tag}}-next"
+changelog:
+  disable: true
+dockers:
+  -
+    goos: linux
+    goarch: amd64
+    ids:
+      - "server"
+    use: buildx
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:{{.Version}}-amd64"
+    dockerfile: "Dockerfile"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}-server"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=BINARY=server"
+      - "--platform=linux/amd64"
+  -
+    goos: linux
+    goarch: arm64
+    ids:
+      - "server"
+    use: buildx
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:{{.Version}}-arm64"
+    dockerfile: "Dockerfile"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}-server"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=BINARY=server"
+      - "--platform=linux/arm64"
+  -
+    goos: linux
+    goarch: amd64
+    ids:
+      - "worker"
+    use: buildx
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:{{.Version}}-amd64"
+    dockerfile: "Dockerfile"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}-worker"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=BINARY=worker"
+      - "--platform=linux/amd64"
+  -
+    goos: linux
+    goarch: arm64
+    ids:
+      - "worker"
+    use: buildx
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:{{.Version}}-arm64"
+    dockerfile: "Dockerfile"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}-worker"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=BINARY=worker"
+      - "--platform=linux/arm64"
+docker_manifests:
+  -
+    name_template: "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:latest"
+    skip_push: '{{ if ne .Env.IS_LATEST_RELEASE "true" }}true{{ end }}'
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:{{.Version}}-amd64"
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:{{.Version}}-arm64"
+  -
+    name_template: "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:{{.Version}}"
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:{{.Version}}-amd64"
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-server:{{.Version}}-arm64"
+  -
+    name_template: "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:latest"
+    skip_push: '{{ if ne .Env.IS_LATEST_RELEASE "true" }}true{{ end }}'
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:{{.Version}}-amd64"
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:{{.Version}}-arm64"
+  -
+    name_template: "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:{{.Version}}"
+    image_templates:
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:{{.Version}}-amd64"
+      - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}-worker:{{.Version}}-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
-FROM golang:1.20 as build
-
-WORKDIR /go/src/github.com/Eun/merge-with-label
-RUN --mount=type=bind,target=/go/src/github.com/Eun/merge-with-label,readwrite \
-    CGO_ENABLED=0 go build -o /go/bin/server github.com/Eun/merge-with-label/cmd/server
-
-RUN --mount=type=bind,target=/go/src/github.com/Eun/merge-with-label,readwrite \
-    CGO_ENABLED=0 go build -o /go/bin/worker github.com/Eun/merge-with-label/cmd/worker
-
 FROM gcr.io/distroless/static-debian11
-COPY --from=build /go/bin/server /bin/
-COPY --from=build /go/bin/worker /bin/
+ARG BINARY
+COPY $BINARY /app
 COPY LICENSE /LICENSE
 COPY licenses /licenses
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
## Summary

Replaces the two-stage build `Dockerfile` with a minimal single-stage runtime image and introduces a `.goreleaser.yml` config (adapted from [`go-bin-template`](https://github.com/Eun/go-bin-template)) so GoReleaser owns the full build + Docker publish pipeline.

### Changes

**`Dockerfile`**
- Removed the Go build stage — binaries are built externally by GoReleaser
- Single-stage `FROM gcr.io/distroless/static-debian11`; accepts `ARG BINARY` so the same Dockerfile produces both the `server` and `worker` images

**`.goreleaser.yml`** (new)
- Two build entries: `server` (`./cmd/server`) and `worker` (`./cmd/worker`), linux-only, amd64 + arm64
- Four `dockers` stanzas: amd64 + arm64 per binary, passing `--build-arg BINARY=<name>`
- Four `docker_manifests`: versioned tag + `:latest` (gated on `IS_LATEST_RELEASE`) for each image
- Images: `ghcr.io/eun/merge-with-label-server` and `ghcr.io/eun/merge-with-label-worker`

**`.github/workflows/release_published.yml`**
- Replaced `docker/build-push-action` with `goreleaser/goreleaser-action@v6`
- Added QEMU + Buildx setup steps (required for multi-arch)
- Added latest-release detection step to drive `IS_LATEST_RELEASE` env var