### PR TITLE
fix: add LICENSE and licenses to docker extra_files in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,9 @@ dockers:
     image_templates:
       - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}:{{.Version}}-amd64"
     dockerfile: "Dockerfile"
+    extra_files:
+      - LICENSE
+      - licenses
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -68,6 +71,9 @@ dockers:
     image_templates:
       - "{{.Env.REGISTRY}}/{{.Env.IMAGE_NAME}}:{{.Version}}-arm64"
     dockerfile: "Dockerfile"
+    extra_files:
+      - LICENSE
+      - licenses
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"


### PR DESCRIPTION
## Problem

The `build_binary` CI step fails because the Docker build context assembled by GoReleaser only contained the compiled binaries (`server`, `worker`) and the `Dockerfile`. The `Dockerfile` also tries to `COPY LICENSE /LICENSE` and `COPY licenses /licenses`, but those files were never staged into the temp build-context directory — causing the Docker build to error out with:

```
"/licenses": not found
"/LICENSE": not found
```

## Fix

Added `extra_files` to both `dockers` entries in `.goreleaser.yml` (amd64 and arm64):

```yaml
extra_files:
  - LICENSE
  - licenses
```

GoReleaser copies these files into the temp build-context directory before invoking `docker buildx build`, so the `COPY` instructions in the `Dockerfile` will now resolve correctly.