### PR TITLE
ci: simplify trigger to push on main and all pull_requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # this workflow runs CI checks on all pushes and pull requests.
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   push:
+    branches: [main]
+  pull_request:
 
 name: "ci"
 jobs:


### PR DESCRIPTION
Simplify the `on:` trigger in `ci.yml`:\n\n- Push: only run on `main` branch (removes noise from feature branches)\n- Pull request: run on all events (removes the explicit types filter)