### PR TITLE
fix: remove invalid ENTRYPOINT from Dockerfile and standardise postgres password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,3 @@ COPY server /server
 COPY worker /worker
 COPY LICENSE /LICENSE
 COPY licenses /licenses
-ENTRYPOINT ["/app"]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ update:
          - ./pg_data:/var/lib/postgresql/data
        environment:
          POSTGRES_USER: supabase_admin
-         POSTGRES_PASSWORD: <your postgres password>
+         POSTGRES_PASSWORD: postgres
          POSTGRES_DB: postgres
        healthcheck:
          test: ["CMD-SHELL", "pg_isready -U supabase_admin -d postgres"]
@@ -114,7 +114,7 @@ update:
          - "8000:8000"
        environment:
          PORT: 8000
-         PostgresDSN: "postgres://supabase_admin:<your postgres password>@postgres:5432/postgres?sslmode=disable"
+         PostgresDSN: "postgres://supabase_admin:postgres@postgres:5432/postgres?sslmode=disable"
        depends_on:
          postgres:
            condition: service_healthy
@@ -131,7 +131,7 @@ update:
        volumes:
          - "./private-key.pem:/private-key.pem:ro"
        environment:
-         PostgresDSN: "postgres://supabase_admin:<your postgres password>@postgres:5432/postgres?sslmode=disable"
+         PostgresDSN: "postgres://supabase_admin:postgres@postgres:5432/postgres?sslmode=disable"
          APP_ID: <your app id>
          PRIVATE_KEY: /private-key.pem
          HEALTH_PORT: 8001

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
       - ./pg_data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: supabase_admin
-      POSTGRES_PASSWORD: mwl
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
     ports:
       - "5432:5432"
@@ -24,7 +24,7 @@ services:
       - "8000:8000"
     environment:
       PORT: 8000
-      PostgresDSN: "postgres://supabase_admin:mwl@postgres:5432/postgres?sslmode=disable"
+      PostgresDSN: "postgres://supabase_admin:postgres@postgres:5432/postgres?sslmode=disable"
     depends_on:
       postgres:
         condition: service_healthy
@@ -42,7 +42,7 @@ services:
     volumes:
       - "./private-key.pem:/private-key.pem:ro"
     environment:
-      PostgresDSN: "postgres://supabase_admin:mwl@postgres:5432/postgres?sslmode=disable"
+      PostgresDSN: "postgres://supabase_admin:postgres@postgres:5432/postgres?sslmode=disable"
       APP_ID: <your app id>
       PRIVATE_KEY: /private-key.pem
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ./pg_data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: supabase_admin
-      POSTGRES_PASSWORD: mwl
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U supabase_admin -d postgres"]
@@ -22,7 +22,7 @@ services:
       - "8000:8000"
     environment:
       PORT: 8000
-      PostgresDSN: "postgres://supabase_admin:mwl@postgres:5432/postgres?sslmode=disable"
+      PostgresDSN: "postgres://supabase_admin:postgres@postgres:5432/postgres?sslmode=disable"
     depends_on:
       postgres:
         condition: service_healthy
@@ -39,7 +39,7 @@ services:
     volumes:
       - "./private-key.pem:/private-key.pem:ro"
     environment:
-      PostgresDSN: "postgres://supabase_admin:mwl@postgres:5432/postgres?sslmode=disable"
+      PostgresDSN: "postgres://supabase_admin:postgres@postgres:5432/postgres?sslmode=disable"
       APP_ID: <your app id>
       PRIVATE_KEY: /private-key.pem
       HEALTH_PORT: 8001


### PR DESCRIPTION
## Problem

The `Dockerfile` has `ENTRYPOINT ["/app"]` but `/app` does not exist in the image — only `/server` and `/worker` are copied. When Docker runs `ENTRYPOINT` + `CMD`, it tries to execute `/app /server` (or `/app /worker`), causing:

```
Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/app": stat /app: no such file or directory: unknown
```

Additionally, the compose files contained `mwl` as a hardcoded internal password and `<your postgres password>` as a placeholder, neither of which work out of the box.

## Changes

- **`Dockerfile`**: Remove the stale `ENTRYPOINT ["/app"]` line. The `command:` in each compose service (`/server`, `/worker`) already acts as the entrypoint.
- **`docker-compose.yml`**: Replace `mwl` and `<your postgres password>` with `postgres`.
- **`docker-compose.dev.yml`**: Replace `mwl` with `postgres`.
- **`README.md`**: Replace `<your postgres password>` placeholder with `postgres`.