### PR TITLE
fix: prevent merge suppression and lost triggers after branch update

### DIFF
--- a/pkg/merge-with-label/pgqueue/store.go
+++ b/pkg/merge-with-label/pgqueue/store.go
@@ -135,7 +135,8 @@ type Job struct {
 // -----------------------------------------------------------------------
 
 // EnqueueRepo inserts a repo-level job.
-// A second call with the same dedup_key is silently ignored (ON CONFLICT DO NOTHING).
+// If a job with the same dedup_key already exists, available_at is advanced to
+// the earlier of the existing and new values so a sooner trigger is never lost.
 func (s *Store) EnqueueRepo(ctx context.Context, dedupKey string, payload []byte, availableAt time.Time) error {
 	if availableAt.IsZero() {
 		availableAt = time.Now()
@@ -143,7 +144,8 @@ func (s *Store) EnqueueRepo(ctx context.Context, dedupKey string, payload []byte
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO mwl_repo_queue (dedup_key, payload, available_at)
 		VALUES ($1, $2, $3)
-		ON CONFLICT (dedup_key) DO NOTHING
+		ON CONFLICT (dedup_key) DO UPDATE
+		    SET available_at = LEAST(EXCLUDED.available_at, mwl_repo_queue.available_at)
 	`, dedupKey, payload, availableAt)
 	return errors.Wrap(err, "enqueue repo")
 }
@@ -168,7 +170,8 @@ func (s *Store) RescheduleRepo(
 // -----------------------------------------------------------------------
 
 // EnqueuePR inserts a per-PR job.
-// A second call with the same dedup_key is silently ignored (ON CONFLICT DO NOTHING).
+// If a job with the same dedup_key already exists, available_at is advanced to
+// the earlier of the existing and new values so a sooner trigger is never lost.
 func (s *Store) EnqueuePR(ctx context.Context, dedupKey string, payload []byte, availableAt time.Time) error {
 	if availableAt.IsZero() {
 		availableAt = time.Now()
@@ -176,7 +179,8 @@ func (s *Store) EnqueuePR(ctx context.Context, dedupKey string, payload []byte, 
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO mwl_pr_queue (dedup_key, payload, available_at)
 		VALUES ($1, $2, $3)
-		ON CONFLICT (dedup_key) DO NOTHING
+		ON CONFLICT (dedup_key) DO UPDATE
+		    SET available_at = LEAST(EXCLUDED.available_at, mwl_pr_queue.available_at)
 	`, dedupKey, payload, availableAt)
 	return errors.Wrap(err, "enqueue pr")
 }

--- a/pkg/merge-with-label/pgqueue/store_test.go
+++ b/pkg/merge-with-label/pgqueue/store_test.go
@@ -366,6 +366,83 @@ func TestDeletePRStateIdempotent(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------
+// Enqueue upsert: available_at advancement
+// -----------------------------------------------------------------------
+
+func TestEnqueuePRUpsertAdvancesAvailableAt(t *testing.T) {
+	ctx := context.Background()
+	key := "pr-upsert-advance-" + t.Name()
+	payload := []byte(`{}`)
+
+	// Insert with a far-future available_at.
+	future := time.Now().Add(10 * time.Minute)
+	if err := sharedStore.EnqueuePR(ctx, key, payload, future); err != nil {
+		t.Fatalf("EnqueuePR (future): %v", err)
+	}
+	// Re-enqueue with now — should pull available_at forward.
+	now := time.Now()
+	if err := sharedStore.EnqueuePR(ctx, key, payload, now); err != nil {
+		t.Fatalf("EnqueuePR (now): %v", err)
+	}
+	// The job must be immediately dequeue-able.
+	job, err := sharedStore.DequeuePR(ctx)
+	if err != nil {
+		t.Fatalf("DequeuePR: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected job to be immediately available after upsert advanced available_at, got nil")
+	}
+}
+
+func TestEnqueuePRUpsertDoesNotRegressAvailableAt(t *testing.T) {
+	ctx := context.Background()
+	key := "pr-upsert-noregress-" + t.Name()
+	payload := []byte(`{}`)
+
+	// Insert with now — job is immediately available.
+	if err := sharedStore.EnqueuePR(ctx, key, payload, time.Time{}); err != nil {
+		t.Fatalf("EnqueuePR (now): %v", err)
+	}
+	// Re-enqueue with far future — must NOT push available_at forward.
+	future := time.Now().Add(10 * time.Minute)
+	if err := sharedStore.EnqueuePR(ctx, key, payload, future); err != nil {
+		t.Fatalf("EnqueuePR (future): %v", err)
+	}
+	// Job must still be immediately dequeue-able.
+	job, err := sharedStore.DequeuePR(ctx)
+	if err != nil {
+		t.Fatalf("DequeuePR: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected job to still be immediately available (available_at must not regress), got nil")
+	}
+}
+
+func TestEnqueueRepoUpsertAdvancesAvailableAt(t *testing.T) {
+	ctx := context.Background()
+	key := "repo-upsert-advance-" + t.Name()
+	payload := []byte(`{}`)
+
+	// Insert with a far-future available_at.
+	future := time.Now().Add(10 * time.Minute)
+	if err := sharedStore.EnqueueRepo(ctx, key, payload, future); err != nil {
+		t.Fatalf("EnqueueRepo (future): %v", err)
+	}
+	// Re-enqueue with now — should pull available_at forward.
+	if err := sharedStore.EnqueueRepo(ctx, key, payload, time.Time{}); err != nil {
+		t.Fatalf("EnqueueRepo (now): %v", err)
+	}
+	// The job must be immediately dequeue-able.
+	job, err := sharedStore.DequeueRepo(ctx)
+	if err != nil {
+		t.Fatalf("DequeueRepo: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected job to be immediately available after upsert advanced available_at, got nil")
+	}
+}
+
+// -----------------------------------------------------------------------
 // WaitForSchema + pg_cron + UNLOGGED
 // -----------------------------------------------------------------------
 

--- a/pkg/merge-with-label/worker/pull_request_worker.go
+++ b/pkg/merge-with-label/worker/pull_request_worker.go
@@ -83,6 +83,14 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 
 	if didUpdatePullRequest && sess.Config.Merge.Labels.ContainsOneOf(details.Labels...) != "" {
 		logger.Debug().Msg("not merging, because pull request was just updated")
+		// Clear the PR state so the rescheduled job is not blocked by the SHA
+		// dedup guard. Without this, the synchronize event fired by the branch
+		// update can race the rescheduled job: if the synchronize job runs
+		// first it records the new SHA, and the rescheduled job then discards
+		// itself as a duplicate before ever attempting the merge.
+		if err := worker.Store.DeletePRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number); err != nil {
+			logger.Warn().Err(err).Msg("unable to clear pr state after update")
+		}
 		return pushBackError{delay: worker.DurationToWaitAfterUpdateBranch}
 	}
 


### PR DESCRIPTION
## Problem

Two bugs prevented branches with `auto-merge` / `auto-update` labels from being reliably updated and merged.

### Bug 1 — SHA dedup discards the merge attempt after a branch update

When `updatePullRequest` succeeds the job is pushed back with a delay so the merge can run after CI passes. Meanwhile the bot's own branch-update push fires a `synchronize` `pull_request` event.

If that synchronize job ran first it re-recorded the new head SHA via `SetPRState`, and the rescheduled (push-back) job then hit the SHA dedup guard at the top of `runLogic` and silently returned `nil` — **merge never attempted**.

**Fix:** call `DeletePRState` immediately before returning the `pushBackError` so the rescheduled job always re-evaluates from scratch. `SetPRState` is kept pre-work so concurrent duplicate jobs still discard themselves correctly.

### Bug 2 — `ON CONFLICT DO NOTHING` silences re-triggers during the push-back window

While a push-back job sits in the queue with a future `available_at`, any new `EnqueuePR` / `EnqueueRepo` call for the same dedup key (e.g. CI check completed, label added, another push to main) was **silently discarded**. The worker always fetches live data from GitHub so the payload is irrelevant — only `available_at` matters.

**Fix:** change both `EnqueuePR` and `EnqueueRepo` to upsert with `LEAST(available_at)` so a sooner trigger always accelerates an existing delayed job. Later triggers are no-ops. No schema migration required.

## Changes

| File | Change |
|---|---|
| `pkg/merge-with-label/worker/pull_request_worker.go` | `DeletePRState` before `pushBackError` after a branch update |
| `pkg/merge-with-label/pgqueue/store.go` | `EnqueuePR` + `EnqueueRepo` upsert `available_at` only |
| `pkg/merge-with-label/pgqueue/store_test.go` | 3 new tests covering the upsert semantics |