### PR TITLE
feat: improve observability with info-level logging in server and worker

### DIFF
--- a/pkg/merge-with-label/server/server.go
+++ b/pkg/merge-with-label/server/server.go
@@ -60,13 +60,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if githubID == "" {
 		githubID = uuid.NewString()
 	}
-	_ = githubID // event ID available for debugging; not yet forwarded to handlers
 
-	logger := h.GetLoggerForContext(r.Context()).With().Str("event", githubEvent).Logger()
+	logger := h.GetLoggerForContext(r.Context()).With().
+		Str("event", githubEvent).
+		Str("delivery", githubID).
+		Logger()
 	if logger.GetLevel() == zerolog.TraceLevel {
-		logger.Trace().Str("body", string(body)).Msg("got event")
+		logger.Trace().Str("body", string(body)).Msg("received webhook")
 	} else {
-		logger.Debug().Msg("got event")
+		logger.Info().Msg("received webhook")
 	}
 
 	baseRequest := h.unmarshalAndValidateRequest(&logger, body, w)
@@ -86,6 +88,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "status":
 		h.handleRepoEvent(r.Context(), &logger, w, baseRequest, "status")
 	default:
+		logger.Info().Msg("ignoring unhandled event type")
 		h.respond(w, http.StatusOK, "ok")
 	}
 }
@@ -93,11 +96,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) unmarshalAndValidateRequest(rootLogger *zerolog.Logger, body []byte, w http.ResponseWriter) *BaseRequest {
 	var req BaseRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		rootLogger.Error().Err(err).Msg("unable to decode request")
+		rootLogger.Error().Err(err).Msg("unable to decode request body")
 		h.respond(w, http.StatusBadRequest, "bad request")
 		return nil
 	}
 	if !req.IsValid(rootLogger) {
+		rootLogger.Debug().Msg("request is not valid, skipping")
 		h.respond(w, http.StatusOK, "ok")
 		return nil
 	}
@@ -111,6 +115,7 @@ func (h *Handler) unmarshalAndValidateRequest(rootLogger *zerolog.Logger, body [
 		h.respond(w, http.StatusOK, "ok")
 		return nil
 	}
+	rootLogger.Info().Str("repo", req.Repository.FullName).Msg("request validated")
 	return &req
 }
 
@@ -137,7 +142,7 @@ func (h *Handler) handleCheckRun(ctx context.Context, logger *zerolog.Logger, bo
 		return
 	}
 	if req.Action != "completed" {
-		logger.Debug().Msg("action is not completed")
+		logger.Info().Str("action", req.Action).Msg("ignoring check_run: action is not completed")
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
@@ -185,23 +190,27 @@ func (h *Handler) handlePullRequest(ctx context.Context, logger *zerolog.Logger,
 		return
 	}
 	if req.PullRequest.Number == 0 {
-		logger.Debug().Msg("no pull_request.number present in request")
+		logger.Info().Msg("ignoring pull_request: no pull_request.number present")
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
 	if req.PullRequest.State != "open" {
-		logger.Debug().Msg("pull_request.state is not `open'")
+		logger.Info().Str("state", req.PullRequest.State).Msg("ignoring pull_request: state is not open")
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
 
 	handleActions := []string{"created", "opened", "labeled", "reopened", "synchronize", "edited"}
 	if slices.Index(handleActions, req.Action) == -1 {
-		logger.Debug().Msgf("action is not one of %s", strings.Join(handleActions, ", "))
+		logger.Info().Str("action", req.Action).Msgf("ignoring pull_request: action is not one of %s", strings.Join(handleActions, ", "))
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
 
+	logger.Info().
+		Str("action", req.Action).
+		Int64("pr", req.PullRequest.Number).
+		Msg("enqueueing pull_request")
 	repo := h.repoFrom(&req.BaseRequest)
 	if err := common.EnqueuePR(ctx, logger, h.Store, h.RateLimitInterval, &common.QueuePRMessage{
 		BaseMessage: common.BaseMessage{InstallationID: req.Installation.ID, Repository: *repo},
@@ -228,17 +237,17 @@ func (h *Handler) handlePullRequestReview(ctx context.Context, logger *zerolog.L
 		return
 	}
 	if req.PullRequest.Number == 0 {
-		logger.Debug().Msg("no pull_request.number present in request")
+		logger.Info().Msg("ignoring pull_request_review: no pull_request.number present")
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
 	if req.PullRequest.State != "open" {
-		logger.Debug().Msg("pull_request.state is not `open'")
+		logger.Info().Str("state", req.PullRequest.State).Msg("ignoring pull_request_review: state is not open")
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
 	if req.Action != "submitted" {
-		logger.Debug().Msg("action is not submitted")
+		logger.Info().Str("action", req.Action).Msg("ignoring pull_request_review: action is not submitted")
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
@@ -267,9 +276,11 @@ func (h *Handler) handlePush(ctx context.Context, logger *zerolog.Logger, body [
 		return
 	}
 	if req.Deleted || req.Ref != "refs/heads/"+req.Repository.DefaultBranch {
+		logger.Info().Str("ref", req.Ref).Msg("ignoring push: not a push to the default branch")
 		h.respond(w, http.StatusOK, "ok")
 		return
 	}
+	logger.Info().Str("ref", req.Ref).Msg("enqueueing repo job for push to default branch")
 	h.enqueueRepoOrError(ctx, logger, w, h.repoFrom(base), base.Installation.ID)
 }
 

--- a/pkg/merge-with-label/worker/pull_request_worker.go
+++ b/pkg/merge-with-label/worker/pull_request_worker.go
@@ -73,6 +73,8 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 		return errors.Wrap(err, "unable to set pr state")
 	}
 
+	logger.Info().Str("sha", details.LastCommitSha).Int("ahead_by", details.AheadBy).Msg("processing pull request")
+
 	stopLogic, didUpdatePullRequest, err := worker.updatePullRequest(ctx, &logger, sess, details)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/merge-with-label/worker/repo_worker.go
+++ b/pkg/merge-with-label/worker/repo_worker.go
@@ -32,5 +32,6 @@ func (worker *repoWorker) runLogic(rootLogger *zerolog.Logger, msg *common.Queue
 		return nil
 	}
 
+	logger.Info().Msg("fanning out PRs for repo event")
 	return worker.fanOutPRs(ctx, &logger, sess)
 }


### PR DESCRIPTION
## Motivation

Webhooks and worker decisions were logged only at `Debug` level, making it impossible to trace why a `labeled` event (or any event) was ignored or processed without enabling `DEBUG=1`. The log error `"unable to decode request"` also provided no context about which event triggered it.

## Investigation findings

### JSON decode error: `invalid character 'x' after top-level value`

The error `"event":"", "message":"unable to decode request"` indicates an incoming POST with no `X-GitHub-Event` header whose body the JSON parser accepted as valid but then found trailing bytes. With the new logging, each request now logs its event type and delivery ID immediately on arrival, so this is trivially traceable.

### `labeled` event not triggering updates

`labeled` is in `handlePullRequest`'s accepted actions list. The likely cause is that the event is being dropped silently before reaching that handler — either by `unmarshalAndValidateRequest` returning nil (e.g. missing `installation.id` or `repository.node_id` in the payload), or by the `pull_request.state != "open"` guard. With the new Info-level logging at every decision point, the exact drop reason will appear in the logs immediately.

## Changes

| File | Change |
|---|---|
| `server.go` | Webhook receipt logged at Info with `event` + `delivery` fields; every ignore/skip reason logged at Info with the relevant field; enqueue actions logged at Info; `delivery` ID forwarded to logger |
| `server.go` | JSON decode error message clarified to `"unable to decode request body"` |
| `pull_request_worker.go` | Processing start (after dedup passes) logged at Info with `sha` + `ahead_by` |
| `repo_worker.go` | Fan-out start logged at Info |

## Log trace example (after this PR)

```
{"level":"info","event":"pull_request","delivery":"abc-123","message":"received webhook"}
{"level":"info","repo":"org/repo","message":"request validated"}
{"level":"info","event":"pull_request","delivery":"abc-123","action":"labeled","pr":42,"message":"enqueueing pull_request"}
{"level":"info","entry":"pull_request","number":42,"repo":"org/repo","sha":"abc...","ahead_by":3,"message":"processing pull request"}
```