### PR TITLE
feat: log job dequeue and dispatch at Info level in worker

### DIFF
--- a/pkg/merge-with-label/worker/worker.go
+++ b/pkg/merge-with-label/worker/worker.go
@@ -116,7 +116,7 @@ func (w *Worker) Consume() error {
 					continue
 				}
 
-				w.Logger.Debug().Str("queue", queueName).Int64("job_id", job.ID).Msg("job dequeued")
+				w.Logger.Info().Str("queue", queueName).Int64("job_id", job.ID).Int("attempt", job.Attempts+1).Msg("job dequeued")
 
 				// Process in a separate goroutine so the poller loop immediately
 				// picks up the next job (up to maxConcurrent).
@@ -145,6 +145,12 @@ func (w *Worker) Consume() error {
 							Str("dedup_key", dedupKey).
 							Int("max_attempts", w.MaxAttempts).
 							Msg("job permanently removed after max attempts")
+					} else {
+						w.Logger.Info().
+							Str("queue", queueName).
+							Str("dedup_key", dedupKey).
+							Dur("retry_in", delay).
+							Msg("job rescheduled")
 					}
 				}(job)
 			}
@@ -161,6 +167,7 @@ func (w *Worker) Consume() error {
 			if !w.isAllowed(logger, &m) {
 				return dedupKey, payload, nil
 			}
+			logger.Info().Str("repo", m.Repository.FullName).Msg("processing repo job")
 			return dedupKey, payload, repoMsgWorker.runLogic(logger, &m)
 		},
 	)
@@ -175,6 +182,7 @@ func (w *Worker) Consume() error {
 			if !w.isAllowed(logger, &m) {
 				return dedupKey, payload, nil
 			}
+			logger.Info().Str("repo", m.Repository.FullName).Int64("pr", m.PullRequest.Number).Msg("processing PR job")
 			return dedupKey, payload, prMsgWorker.runLogic(logger, &m)
 		},
 	)


### PR DESCRIPTION
## Problem

With two workers running, the server logs showed `"enqueueing pull_request"` but neither worker showed any sign of picking up the work. All worker dequeue and dispatch logging was at `Debug` level, so with default (`Info`) logging the workers appeared silent.

## Changes (`worker.go`)

| Line | Before | After |
|---|---|---|
| Job dequeued | `Debug` — job_id only | `Info` — job_id + **attempt number** (1-based) |
| PR job dispatched | *(missing)* | `Info` — **repo + PR number** — emitted by whichever replica wins the row |
| Repo job dispatched | *(missing)* | `Info` — **repo name** |
| Job rescheduled | *(missing)* | `Info` — dedup_key + **retry_in** duration |

## Expected log trace (two workers, one picks up a PR job)

**Worker A (wins the SKIP LOCKED row):**
```json
{"level":"info","queue":"mwl_pr_queue","job_id":42,"attempt":1,"message":"job dequeued"}
{"level":"info","repo":"org/repo","pr":7,"message":"processing PR job"}
{"level":"info","entry":"pull_request","number":7,"repo":"org/repo","sha":"abc...","ahead_by":2,"message":"processing pull request"}
```

**Worker B (queue empty when it polls):**
*(no output — correct)*

If the branch update causes a push-back:
```json
{"level":"info","queue":"mwl_pr_queue","dedup_key":"pr:MDEx...:7","retry_in":"30s","message":"job rescheduled"}
```