### PR TITLE
fix: track base branch SHA in PR state to re-evaluate after base push

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Eun/go-gen-graphql v0.0.3
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/pkg/errors v0.9.1
@@ -35,7 +36,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/pkg/merge-with-label/github/github.go
+++ b/pkg/merge-with-label/github/github.go
@@ -430,6 +430,7 @@ type PullRequestDetails struct {
 	ApprovedBy       []string
 	Author           string
 	BaseRefName      string
+	BaseRefOid       string
 	CheckStates      map[string]string
 	HasConflicts     bool
 	HeadRefID        string
@@ -530,6 +531,11 @@ func GetPullRequestDetails(
 							} `json:"commit"`
 						} `json:"nodes"`
 					} `json:"commits" graphql:"commits(last:1)"`
+					BaseRef struct {
+						Target struct {
+							Oid string `json:"oid"`
+						} `json:"target"`
+					} `json:"baseRef"`
 					HeadRef struct {
 						Compare struct {
 							AheadBy int `json:"aheadBy"`
@@ -600,6 +606,7 @@ func GetPullRequestDetails(
 		ApprovedBy:       make([]string, len(response.Data.Repository.PullRequest.Reviews.Nodes)),
 		Author:           response.Data.Repository.PullRequest.Author.Login,
 		BaseRefName:      baseName,
+		BaseRefOid:       response.Data.Repository.PullRequest.BaseRef.Target.Oid,
 		HasConflicts:     response.Data.Repository.PullRequest.Mergeable == "CONFLICTING",
 		HeadRefID:        response.Data.Repository.PullRequest.HeadRef.ID,
 		HeadRefName:      response.Data.Repository.PullRequest.HeadRef.Name,

--- a/pkg/merge-with-label/pgqueue/migrations/00002_pr_state_base_sha.sql
+++ b/pkg/merge-with-label/pgqueue/migrations/00002_pr_state_base_sha.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE mwl_pr_state ADD COLUMN base_sha TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE mwl_pr_state DROP COLUMN base_sha;

--- a/pkg/merge-with-label/pgqueue/store.go
+++ b/pkg/merge-with-label/pgqueue/store.go
@@ -300,6 +300,7 @@ func (s *Store) KVSet(ctx context.Context, bucket, key string, value []byte, ttl
 // PRStateResult is returned by GetPRState.
 type PRStateResult struct {
 	HeadSHA   string
+	BaseSHA   string
 	UpdatedAt time.Time
 }
 
@@ -307,9 +308,9 @@ type PRStateResult struct {
 func (s *Store) GetPRState(ctx context.Context, repoNodeID string, prNumber int64) (*PRStateResult, error) {
 	var r PRStateResult
 	err := s.pool.QueryRow(ctx, `
-		SELECT head_sha, updated_at FROM mwl_pr_state
+		SELECT head_sha, base_sha, updated_at FROM mwl_pr_state
 		WHERE repo_node_id = $1 AND pr_number = $2
-	`, repoNodeID, prNumber).Scan(&r.HeadSHA, &r.UpdatedAt)
+	`, repoNodeID, prNumber).Scan(&r.HeadSHA, &r.BaseSHA, &r.UpdatedAt)
 	if err != nil {
 		if isNoRows(err) {
 			return nil, nil //nolint:nilnil // cache miss is not an error
@@ -328,15 +329,16 @@ func (s *Store) DeletePRState(ctx context.Context, repoNodeID string, prNumber i
 	return errors.Wrap(err, "delete pr state")
 }
 
-// SetPRState upserts the last-seen head SHA for a PR.
-func (s *Store) SetPRState(ctx context.Context, repoNodeID string, prNumber int64, headSHA string) error {
+// SetPRState upserts the last-seen (head, base) SHA pair for a PR.
+func (s *Store) SetPRState(ctx context.Context, repoNodeID string, prNumber int64, headSHA, baseSHA string) error {
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO mwl_pr_state (repo_node_id, pr_number, head_sha, updated_at)
-		VALUES ($1, $2, $3, NOW())
+		INSERT INTO mwl_pr_state (repo_node_id, pr_number, head_sha, base_sha, updated_at)
+		VALUES ($1, $2, $3, $4, NOW())
 		ON CONFLICT (repo_node_id, pr_number) DO UPDATE
 		    SET head_sha   = EXCLUDED.head_sha,
+		        base_sha   = EXCLUDED.base_sha,
 		        updated_at = NOW()
-	`, repoNodeID, prNumber, headSHA)
+	`, repoNodeID, prNumber, headSHA, baseSHA)
 	return errors.Wrap(err, "set pr state")
 }
 

--- a/pkg/merge-with-label/pgqueue/store_test.go
+++ b/pkg/merge-with-label/pgqueue/store_test.go
@@ -284,7 +284,7 @@ func TestKVOverwrite(t *testing.T) {
 
 func TestSetGetPRState(t *testing.T) {
 	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, t.Name(), 42, "sha-abc"); err != nil {
+	if err := sharedStore.SetPRState(ctx, t.Name(), 42, "sha-abc", "base-sha-abc"); err != nil {
 		t.Fatalf("SetPRState: %v", err)
 	}
 	state, err := sharedStore.GetPRState(ctx, t.Name(), 42)
@@ -296,6 +296,9 @@ func TestSetGetPRState(t *testing.T) {
 	}
 	if state.HeadSHA != "sha-abc" {
 		t.Errorf("HeadSHA = %q, want %q", state.HeadSHA, "sha-abc")
+	}
+	if state.BaseSHA != "base-sha-abc" {
+		t.Errorf("BaseSHA = %q, want %q", state.BaseSHA, "base-sha-abc")
 	}
 }
 
@@ -312,10 +315,10 @@ func TestPRStateMiss(t *testing.T) {
 
 func TestPRStateOverwrite(t *testing.T) {
 	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, t.Name(), 1, "old-sha"); err != nil {
+	if err := sharedStore.SetPRState(ctx, t.Name(), 1, "old-sha", "old-base"); err != nil {
 		t.Fatal(err)
 	}
-	if err := sharedStore.SetPRState(ctx, t.Name(), 1, "new-sha"); err != nil {
+	if err := sharedStore.SetPRState(ctx, t.Name(), 1, "new-sha", "new-base"); err != nil {
 		t.Fatal(err)
 	}
 	state, err := sharedStore.GetPRState(ctx, t.Name(), 1)
@@ -323,13 +326,16 @@ func TestPRStateOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	if state.HeadSHA != "new-sha" {
-		t.Errorf("expected overwrite, got %q", state.HeadSHA)
+		t.Errorf("expected HeadSHA overwrite, got %q", state.HeadSHA)
+	}
+	if state.BaseSHA != "new-base" {
+		t.Errorf("expected BaseSHA overwrite, got %q", state.BaseSHA)
 	}
 }
 
 func TestPRStateScopedToRepo(t *testing.T) {
 	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, "repo-A-"+t.Name(), 1, "sha-a"); err != nil {
+	if err := sharedStore.SetPRState(ctx, "repo-A-"+t.Name(), 1, "sha-a", "base-a"); err != nil {
 		t.Fatal(err)
 	}
 	state, err := sharedStore.GetPRState(ctx, "repo-B-"+t.Name(), 1)
@@ -343,7 +349,7 @@ func TestPRStateScopedToRepo(t *testing.T) {
 
 func TestDeletePRState(t *testing.T) {
 	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, t.Name(), 5, "sha"); err != nil {
+	if err := sharedStore.SetPRState(ctx, t.Name(), 5, "sha", "base"); err != nil {
 		t.Fatal(err)
 	}
 	if err := sharedStore.DeletePRState(ctx, t.Name(), 5); err != nil {

--- a/pkg/merge-with-label/worker/pull_request_worker.go
+++ b/pkg/merge-with-label/worker/pull_request_worker.go
@@ -61,15 +61,22 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 		return errors.Wrap(err, "unable to get pr state")
 	}
 	if prState != nil && prState.HeadSHA == details.LastCommitSha {
+		if prState.BaseSHA == details.BaseRefOid {
+			logger.Debug().
+				Str("sha", details.LastCommitSha).
+				Msg("pr state sha matches last seen sha, discarding duplicate event")
+			return nil
+		}
 		logger.Debug().
-			Str("sha", details.LastCommitSha).
-			Msg("pr state sha matches last seen sha, discarding duplicate event")
-		return nil
+			Str("head_sha", details.LastCommitSha).
+			Str("old_base_sha", prState.BaseSHA).
+			Str("new_base_sha", details.BaseRefOid).
+			Msg("pr state head sha matches but base moved, re-evaluating")
 	}
 
 	// Record the new SHA before we do the work so a concurrent duplicate job
 	// (if it slipped past the dedup key) also discards itself.
-	if err := worker.Store.SetPRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number, details.LastCommitSha); err != nil {
+	if err := worker.Store.SetPRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number, details.LastCommitSha, details.BaseRefOid); err != nil {
 		return errors.Wrap(err, "unable to set pr state")
 	}
 

--- a/pkg/merge-with-label/worker/pull_request_worker.go
+++ b/pkg/merge-with-label/worker/pull_request_worker.go
@@ -76,7 +76,9 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 
 	// Record the new SHA before we do the work so a concurrent duplicate job
 	// (if it slipped past the dedup key) also discards itself.
-	if err := worker.Store.SetPRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number, details.LastCommitSha, details.BaseRefOid); err != nil {
+	if err := worker.Store.SetPRState(
+		ctx, msg.Repository.NodeID, msg.PullRequest.Number, details.LastCommitSha, details.BaseRefOid,
+	); err != nil {
 		return errors.Wrap(err, "unable to set pr state")
 	}
 


### PR DESCRIPTION
The PR-state dedup cache previously stored only the PR HEAD commit SHA. When main (the base branch) received a new push, the worker correctly re-queued the PR job via push→fanOutPRs, but then immediately discarded it because the PR HEAD SHA was unchanged:

  'pr state sha matches last seen sha, discarding duplicate event'

This meant open PRs with an 'update' or 'merge' (+ RequireLinearHistory) label were never updated/merged after a base-branch push.

Fix: store the base-branch tip commit SHA (BaseRefOid) alongside the PR HEAD SHA in mwl_pr_state. The dedup guard now requires BOTH SHAs to match before discarding the job. When main moves forward, the base SHA changes, the guard no longer fires, and updatePullRequest correctly handles the increased AheadBy.

Changes:
- migrations/00002: add base_sha column to mwl_pr_state
- pgqueue/store: PRStateResult.BaseSHA, updated GetPRState/SetPRState
- github/github.go: BaseRefOid field + baseRef.target.oid in GraphQL query
- worker/pull_request_worker: guard checks both head+base SHA; logs when head matches but base moved
- pgqueue/store_test: update SetPRState call sites and assert BaseSHA



