### PR TITLE
fix: replace SHA guard with decision-state fingerprint in mwl_pr_state

### DIFF
--- a/pkg/merge-with-label/github/github.go
+++ b/pkg/merge-with-label/github/github.go
@@ -430,7 +430,6 @@ type PullRequestDetails struct {
 	ApprovedBy       []string
 	Author           string
 	BaseRefName      string
-	BaseRefOid       string
 	CheckStates      map[string]string
 	HasConflicts     bool
 	HeadRefID        string
@@ -531,11 +530,6 @@ func GetPullRequestDetails(
 							} `json:"commit"`
 						} `json:"nodes"`
 					} `json:"commits" graphql:"commits(last:1)"`
-					BaseRef struct {
-						Target struct {
-							Oid string `json:"oid"`
-						} `json:"target"`
-					} `json:"baseRef"`
 					HeadRef struct {
 						Compare struct {
 							AheadBy int `json:"aheadBy"`
@@ -606,7 +600,6 @@ func GetPullRequestDetails(
 		ApprovedBy:       make([]string, len(response.Data.Repository.PullRequest.Reviews.Nodes)),
 		Author:           response.Data.Repository.PullRequest.Author.Login,
 		BaseRefName:      baseName,
-		BaseRefOid:       response.Data.Repository.PullRequest.BaseRef.Target.Oid,
 		HasConflicts:     response.Data.Repository.PullRequest.Mergeable == "CONFLICTING",
 		HeadRefID:        response.Data.Repository.PullRequest.HeadRef.ID,
 		HeadRefName:      response.Data.Repository.PullRequest.HeadRef.Name,

--- a/pkg/merge-with-label/pgqueue/migrations/00003_drop_mwl_pr_state.sql
+++ b/pkg/merge-with-label/pgqueue/migrations/00003_drop_mwl_pr_state.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+DROP TABLE IF EXISTS mwl_pr_state;
+
+-- +goose Down
+CREATE TABLE IF NOT EXISTS mwl_pr_state (
+    repo_node_id TEXT        NOT NULL,
+    pr_number    BIGINT      NOT NULL,
+    head_sha     TEXT        NOT NULL,
+    base_sha     TEXT        NOT NULL DEFAULT '',
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (repo_node_id, pr_number)
+);

--- a/pkg/merge-with-label/pgqueue/migrations/00004_create_mwl_pr_lock.sql
+++ b/pkg/merge-with-label/pgqueue/migrations/00004_create_mwl_pr_lock.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+
+-- mwl_pr_state stores a fingerprint of the decision-relevant state of a PR
+-- at the time it was last processed. A run that fetches the same state as the
+-- last run produces the same hash and is silently skipped; a run that sees a
+-- changed state (new approval, check pass, label change, commit, etc.) produces
+-- a different hash and proceeds.
+--
+-- This satisfies three requirements:
+--   1. No double-run on concurrent goroutines — first goroutine writes the hash
+--      before work; a concurrent goroutine fetching the same GitHub state sees
+--      the same hash and skips.
+--   2. No re-run when nothing meaningful changed — an unrelated status/push event
+--      fans out to all labeled PRs; the worker fetches details, computes the same
+--      hash, and skips without doing any work.
+--   3. Always re-run when something actionable changed — approval, check pass,
+--      label change, commit — each changes a tracked field, producing a new hash.
+--
+-- UNLOGGED: writes are not WAL-logged so upserts are fast. On crash recovery the
+-- table is truncated, which is safe — all entries are treated as cache misses and
+-- the next run re-evaluates from fresh GitHub state.
+CREATE UNLOGGED TABLE IF NOT EXISTS mwl_pr_state (
+    repo_node_id TEXT        NOT NULL,
+    pr_number    BIGINT      NOT NULL,
+    state_hash   TEXT        NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (repo_node_id, pr_number)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS mwl_pr_state;

--- a/pkg/merge-with-label/pgqueue/store.go
+++ b/pkg/merge-with-label/pgqueue/store.go
@@ -294,52 +294,36 @@ func (s *Store) KVSet(ctx context.Context, bucket, key string, value []byte, ttl
 }
 
 // -----------------------------------------------------------------------
-// PR state cache
+// PR decision-state fingerprint
 // -----------------------------------------------------------------------
 
-// PRStateResult is returned by GetPRState.
-type PRStateResult struct {
-	HeadSHA   string
-	BaseSHA   string
-	UpdatedAt time.Time
-}
-
-// GetPRState returns the last-seen head SHA for a PR, or nil if not cached.
-func (s *Store) GetPRState(ctx context.Context, repoNodeID string, prNumber int64) (*PRStateResult, error) {
-	var r PRStateResult
+// GetPRStateHash returns the stored decision-state fingerprint for a PR, or
+// "" if no state has been recorded yet (cache miss).
+func (s *Store) GetPRStateHash(ctx context.Context, repoNodeID string, prNumber int64) (string, error) {
+	var hash string
 	err := s.pool.QueryRow(ctx, `
-		SELECT head_sha, base_sha, updated_at FROM mwl_pr_state
+		SELECT state_hash FROM mwl_pr_state
 		WHERE repo_node_id = $1 AND pr_number = $2
-	`, repoNodeID, prNumber).Scan(&r.HeadSHA, &r.BaseSHA, &r.UpdatedAt)
+	`, repoNodeID, prNumber).Scan(&hash)
 	if err != nil {
 		if isNoRows(err) {
-			return nil, nil //nolint:nilnil // cache miss is not an error
+			return "", nil // cache miss
 		}
-		return nil, errors.Wrap(err, "get pr state")
+		return "", errors.Wrap(err, "get pr state hash")
 	}
-	return &r, nil
+	return hash, nil
 }
 
-// DeletePRState removes the cached state for a PR that is no longer open
-// (closed, merged). This keeps mwl_pr_state from accumulating dead rows.
-func (s *Store) DeletePRState(ctx context.Context, repoNodeID string, prNumber int64) error {
+// SetPRStateHash upserts the decision-state fingerprint for a PR.
+func (s *Store) SetPRStateHash(ctx context.Context, repoNodeID string, prNumber int64, hash string) error {
 	_, err := s.pool.Exec(ctx, `
-		DELETE FROM mwl_pr_state WHERE repo_node_id = $1 AND pr_number = $2
-	`, repoNodeID, prNumber)
-	return errors.Wrap(err, "delete pr state")
-}
-
-// SetPRState upserts the last-seen (head, base) SHA pair for a PR.
-func (s *Store) SetPRState(ctx context.Context, repoNodeID string, prNumber int64, headSHA, baseSHA string) error {
-	_, err := s.pool.Exec(ctx, `
-		INSERT INTO mwl_pr_state (repo_node_id, pr_number, head_sha, base_sha, updated_at)
-		VALUES ($1, $2, $3, $4, NOW())
+		INSERT INTO mwl_pr_state (repo_node_id, pr_number, state_hash, updated_at)
+		VALUES ($1, $2, $3, NOW())
 		ON CONFLICT (repo_node_id, pr_number) DO UPDATE
-		    SET head_sha   = EXCLUDED.head_sha,
-		        base_sha   = EXCLUDED.base_sha,
+		    SET state_hash = EXCLUDED.state_hash,
 		        updated_at = NOW()
-	`, repoNodeID, prNumber, headSHA, baseSHA)
-	return errors.Wrap(err, "set pr state")
+	`, repoNodeID, prNumber, hash)
+	return errors.Wrap(err, "set pr state hash")
 }
 
 // QueryRow executes a query that returns at most one row.

--- a/pkg/merge-with-label/pgqueue/store_test.go
+++ b/pkg/merge-with-label/pgqueue/store_test.go
@@ -279,99 +279,6 @@ func TestKVOverwrite(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------
-// PR state
-// -----------------------------------------------------------------------
-
-func TestSetGetPRState(t *testing.T) {
-	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, t.Name(), 42, "sha-abc", "base-sha-abc"); err != nil {
-		t.Fatalf("SetPRState: %v", err)
-	}
-	state, err := sharedStore.GetPRState(ctx, t.Name(), 42)
-	if err != nil {
-		t.Fatalf("GetPRState: %v", err)
-	}
-	if state == nil {
-		t.Fatal("expected state, got nil")
-	}
-	if state.HeadSHA != "sha-abc" {
-		t.Errorf("HeadSHA = %q, want %q", state.HeadSHA, "sha-abc")
-	}
-	if state.BaseSHA != "base-sha-abc" {
-		t.Errorf("BaseSHA = %q, want %q", state.BaseSHA, "base-sha-abc")
-	}
-}
-
-func TestPRStateMiss(t *testing.T) {
-	ctx := context.Background()
-	state, err := sharedStore.GetPRState(ctx, "unknown-"+t.Name(), 1)
-	if err != nil {
-		t.Fatalf("GetPRState: %v", err)
-	}
-	if state != nil {
-		t.Error("expected nil on miss")
-	}
-}
-
-func TestPRStateOverwrite(t *testing.T) {
-	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, t.Name(), 1, "old-sha", "old-base"); err != nil {
-		t.Fatal(err)
-	}
-	if err := sharedStore.SetPRState(ctx, t.Name(), 1, "new-sha", "new-base"); err != nil {
-		t.Fatal(err)
-	}
-	state, err := sharedStore.GetPRState(ctx, t.Name(), 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state.HeadSHA != "new-sha" {
-		t.Errorf("expected HeadSHA overwrite, got %q", state.HeadSHA)
-	}
-	if state.BaseSHA != "new-base" {
-		t.Errorf("expected BaseSHA overwrite, got %q", state.BaseSHA)
-	}
-}
-
-func TestPRStateScopedToRepo(t *testing.T) {
-	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, "repo-A-"+t.Name(), 1, "sha-a", "base-a"); err != nil {
-		t.Fatal(err)
-	}
-	state, err := sharedStore.GetPRState(ctx, "repo-B-"+t.Name(), 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state != nil {
-		t.Error("PR state must be scoped to repo_node_id")
-	}
-}
-
-func TestDeletePRState(t *testing.T) {
-	ctx := context.Background()
-	if err := sharedStore.SetPRState(ctx, t.Name(), 5, "sha", "base"); err != nil {
-		t.Fatal(err)
-	}
-	if err := sharedStore.DeletePRState(ctx, t.Name(), 5); err != nil {
-		t.Fatalf("DeletePRState: %v", err)
-	}
-	state, err := sharedStore.GetPRState(ctx, t.Name(), 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state != nil {
-		t.Error("expected nil after delete")
-	}
-}
-
-func TestDeletePRStateIdempotent(t *testing.T) {
-	ctx := context.Background()
-	if err := sharedStore.DeletePRState(ctx, "ghost-"+t.Name(), 99); err != nil {
-		t.Errorf("DeletePRState on missing row: %v", err)
-	}
-}
-
-// -----------------------------------------------------------------------
 // Enqueue upsert: available_at advancement
 // -----------------------------------------------------------------------
 
@@ -487,5 +394,81 @@ func TestKVUnloggedAndCron(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 cron job named mwl_kv_cleanup, got %d", count)
+	}
+}
+
+// -----------------------------------------------------------------------
+// PR decision-state fingerprint
+// -----------------------------------------------------------------------
+
+func TestGetSetPRStateHash(t *testing.T) {
+	ctx := context.Background()
+
+	// Cache miss returns empty string.
+	hash, err := sharedStore.GetPRStateHash(ctx, t.Name(), 1)
+	if err != nil {
+		t.Fatalf("GetPRStateHash (miss): %v", err)
+	}
+	if hash != "" {
+		t.Errorf("expected empty on miss, got %q", hash)
+	}
+
+	// Set a hash.
+	if err := sharedStore.SetPRStateHash(ctx, t.Name(), 1, "abc123"); err != nil {
+		t.Fatalf("SetPRStateHash: %v", err)
+	}
+
+	// Get returns the stored hash.
+	hash, err = sharedStore.GetPRStateHash(ctx, t.Name(), 1)
+	if err != nil {
+		t.Fatalf("GetPRStateHash (hit): %v", err)
+	}
+	if hash != "abc123" {
+		t.Errorf("GetPRStateHash = %q, want %q", hash, "abc123")
+	}
+}
+
+func TestSetPRStateHashOverwrite(t *testing.T) {
+	ctx := context.Background()
+	if err := sharedStore.SetPRStateHash(ctx, t.Name(), 1, "old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sharedStore.SetPRStateHash(ctx, t.Name(), 1, "new"); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := sharedStore.GetPRStateHash(ctx, t.Name(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash != "new" {
+		t.Errorf("expected overwrite, got %q", hash)
+	}
+}
+
+func TestPRStateHashScopedToRepo(t *testing.T) {
+	ctx := context.Background()
+	if err := sharedStore.SetPRStateHash(ctx, "repo-A-"+t.Name(), 1, "hash-a"); err != nil {
+		t.Fatal(err)
+	}
+	// Different repo, same PR number — must be a miss.
+	hash, err := sharedStore.GetPRStateHash(ctx, "repo-B-"+t.Name(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash != "" {
+		t.Error("pr state hash must be scoped to repo_node_id")
+	}
+}
+
+func TestPRStateIsUnlogged(t *testing.T) {
+	ctx := context.Background()
+	var persistence string
+	if err := sharedStore.QueryRow(ctx,
+		`SELECT relpersistence FROM pg_class WHERE relname = 'mwl_pr_state'`,
+	).Scan(&persistence); err != nil {
+		t.Fatalf("query relpersistence: %v", err)
+	}
+	if persistence != "u" {
+		t.Errorf("mwl_pr_state relpersistence = %q, want 'u' (unlogged)", persistence)
 	}
 }

--- a/pkg/merge-with-label/worker/hash.go
+++ b/pkg/merge-with-label/worker/hash.go
@@ -1,11 +1,56 @@
 package worker
 
 import (
+	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Eun/merge-with-label/pkg/merge-with-label/github"
 )
 
 func hashForKV(name string) string {
 	h := sha512.Sum512([]byte(name))
+	return hex.EncodeToString(h[:])
+}
+
+// prStateHash computes a deterministic SHA-256 fingerprint over all fields of
+// PullRequestDetails that the worker uses to decide whether to merge or update
+// a PR. Fields used only for logging, branch naming, or node IDs are excluded.
+//
+// Two calls with identical decision-relevant state return the same hash; any
+// change to approvals, check results, labels, commit SHA, ahead-by count, or
+// mergeability produces a different hash.
+func prStateHash(details *github.PullRequestDetails) string {
+	// Sort slices for determinism — GitHub may return items in arbitrary order.
+	labels := make([]string, len(details.Labels))
+	copy(labels, details.Labels)
+	sort.Strings(labels)
+
+	approvedBy := make([]string, len(details.ApprovedBy))
+	copy(approvedBy, details.ApprovedBy)
+	sort.Strings(approvedBy)
+
+	// Flatten CheckStates map to a sorted "name=state" list.
+	checkPairs := make([]string, 0, len(details.CheckStates))
+	for name, state := range details.CheckStates {
+		checkPairs = append(checkPairs, name+"="+state)
+	}
+	sort.Strings(checkPairs)
+
+	input := strings.Join([]string{
+		details.LastCommitSha,
+		fmt.Sprintf("%d", details.AheadBy),
+		strings.Join(labels, ","),
+		strings.Join(approvedBy, ","),
+		strings.Join(checkPairs, ","),
+		fmt.Sprintf("%t", details.IsMergeable),
+		fmt.Sprintf("%t", details.HasConflicts),
+		details.MergeStateStatus,
+	}, "|")
+
+	h := sha256.Sum256([]byte(input))
 	return hex.EncodeToString(h[:])
 }

--- a/pkg/merge-with-label/worker/pull_request_worker.go
+++ b/pkg/merge-with-label/worker/pull_request_worker.go
@@ -39,10 +39,6 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 
 	if details.State != "OPEN" {
 		logger.Debug().Msg("pull request is not open anymore")
-		// PR is closed or merged — no need to track its state anymore.
-		if err := worker.Store.DeletePRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number); err != nil {
-			logger.Warn().Err(err).Msg("unable to delete pr state for closed pr")
-		}
 		return nil
 	}
 	if details.LastCommitTime.IsZero() || details.LastCommitSha == "" {
@@ -50,36 +46,32 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 		return nil
 	}
 
-	// PR-state deduplication: if we already processed this exact head SHA for
-	// this PR, skip the update/merge logic to avoid double-triggering.
-	// This is the second defense line — it catches the case where two events
-	// with different dedup keys both get dequeued before either is processed
-	// (e.g. two concurrent worker replicas, or events arriving after the first
-	// job was already consumed).
-	prState, err := worker.Store.GetPRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number)
+	// Compute a fingerprint of all fields that drive the merge/update decision.
+	// This fingerprint is the dedup key: two runs that see identical GitHub state
+	// make identical decisions, so the second is a pure duplicate and can be
+	// skipped. If anything changed (new approval, check pass, label change,
+	// commit, base-branch advance) the hash differs and the run proceeds.
+	//
+	// Writing the hash before doing work also blocks a concurrent goroutine that
+	// races on the same PR: since the queue row is deleted on dequeue the dedup
+	// key is free, so a new event can enqueue a fresh row before the first run
+	// finishes. That second goroutine fetches the same GitHub state, computes the
+	// same hash, and skips — exactly like a duplicate.
+	hash := prStateHash(details)
+
+	lastHash, err := worker.Store.GetPRStateHash(ctx, msg.Repository.NodeID, msg.PullRequest.Number)
 	if err != nil {
-		return errors.Wrap(err, "unable to get pr state")
+		return errors.Wrap(err, "unable to get pr state hash")
 	}
-	if prState != nil && prState.HeadSHA == details.LastCommitSha {
-		if prState.BaseSHA == details.BaseRefOid {
-			logger.Debug().
-				Str("sha", details.LastCommitSha).
-				Msg("pr state sha matches last seen sha, discarding duplicate event")
-			return nil
-		}
+	if lastHash == hash {
 		logger.Debug().
-			Str("head_sha", details.LastCommitSha).
-			Str("old_base_sha", prState.BaseSHA).
-			Str("new_base_sha", details.BaseRefOid).
-			Msg("pr state head sha matches but base moved, re-evaluating")
+			Str("hash", hash).
+			Msg("pr decision state unchanged since last run, skipping")
+		return nil
 	}
 
-	// Record the new SHA before we do the work so a concurrent duplicate job
-	// (if it slipped past the dedup key) also discards itself.
-	if err := worker.Store.SetPRState(
-		ctx, msg.Repository.NodeID, msg.PullRequest.Number, details.LastCommitSha, details.BaseRefOid,
-	); err != nil {
-		return errors.Wrap(err, "unable to set pr state")
+	if err := worker.Store.SetPRStateHash(ctx, msg.Repository.NodeID, msg.PullRequest.Number, hash); err != nil {
+		return errors.Wrap(err, "unable to set pr state hash")
 	}
 
 	logger.Info().Str("sha", details.LastCommitSha).Int("ahead_by", details.AheadBy).Msg("processing pull request")
@@ -94,14 +86,6 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 
 	if didUpdatePullRequest && sess.Config.Merge.Labels.ContainsOneOf(details.Labels...) != "" {
 		logger.Debug().Msg("not merging, because pull request was just updated")
-		// Clear the PR state so the rescheduled job is not blocked by the SHA
-		// dedup guard. Without this, the synchronize event fired by the branch
-		// update can race the rescheduled job: if the synchronize job runs
-		// first it records the new SHA, and the rescheduled job then discards
-		// itself as a duplicate before ever attempting the merge.
-		if err := worker.Store.DeletePRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number); err != nil {
-			logger.Warn().Err(err).Msg("unable to clear pr state after update")
-		}
 		return pushBackError{delay: worker.DurationToWaitAfterUpdateBranch}
 	}
 
@@ -115,10 +99,6 @@ func (worker *pullRequestWorker) runLogic(rootLogger *zerolog.Logger, msg *commo
 	}
 
 	if didMergePullRequest {
-		// PR is merged — remove its state row so mwl_pr_state stays clean.
-		if err := worker.Store.DeletePRState(ctx, msg.Repository.NodeID, msg.PullRequest.Number); err != nil {
-			logger.Warn().Err(err).Msg("unable to delete pr state after merge")
-		}
 		if sess.Config.Merge.DeleteBranch {
 			logger.Info().Str("branch", details.HeadRefName).Msg("deleting branch")
 			if err := github.DeleteRef(ctx, worker.HTTPClient, sess.AccessToken, details.HeadRefID); err != nil {


### PR DESCRIPTION
## Problem

The original `mwl_pr_state` stored `(HeadSHA, BaseSHA)` and blocked re-evaluation whenever both SHAs matched. This correctly prevented concurrent duplicate runs but permanently suppressed any event that changed merge-readiness without advancing a commit SHA:

- Reviewer approves a PR → discarded
- Required CI check transitions to passing → discarded
- `merge`/`update` label added to already-processed PR → discarded

An earlier iteration replaced this with a mutex table (`mwl_pr_lock`) — but a mutex that always unlocks after each run fails requirement 2: every unrelated `status` event would re-run the full logic on all labeled PRs even if nothing changed.

## Solution: decision-state fingerprint

Store a SHA-256 hash of all fields that drive the merge/update decision. Two runs that fetch identical GitHub state produce the same hash and the second is skipped. Any change to any tracked dimension produces a different hash and the run proceeds.

**Fingerprint:** `LastCommitSha | AheadBy | sorted(Labels) | sorted(ApprovedBy) | sorted(CheckStates) | IsMergeable | HasConflicts | MergeStateStatus`

These are exactly the fields read by `shouldSkipMerge`, `shouldSkipUpdate`, and `updatePullRequest`.

## Three requirements satisfied

| Requirement | Mechanism |
|---|---|
| **1. No double-run on concurrent goroutines** | First goroutine writes hash before work. Concurrent goroutine fetches same GitHub state → same hash → skip. |
| **2. No re-run when nothing changed** | Unrelated `status`/`push` fans out; worker fetches same details → same hash → skip. Zero wasted work. |
| **3. Always re-run on approval / check-pass / label / commit** | Each changes a tracked field → different hash → run proceeds. |

## Changes

| File | Change |
|---|---|
| `migrations/00003_drop_mwl_pr_state.sql` | Drop old SHA-pair table |
| `migrations/00004_create_mwl_pr_lock.sql` | Create new `mwl_pr_state` with `state_hash TEXT` (UNLOGGED) |
| `pgqueue/store.go` | Replace `AcquirePRLock`/`ReleasePRLock` with `GetPRStateHash`/`SetPRStateHash` |
| `pgqueue/store_test.go` | Replace lock tests with hash round-trip tests |
| `worker/hash.go` | Add `prStateHash(details)` function |
| `worker/pull_request_worker.go` | Replace lock pattern with hash guard |
| `github/github.go` | Remove `BaseRefOid` field (only existed for old SHA guard) |